### PR TITLE
Replaces `mariadb-client` with `mysql-client-5.6`.

### DIFF
--- a/tasks/utilities.yml
+++ b/tasks/utilities.yml
@@ -4,5 +4,5 @@
   apt: name={{ item }} state=latest
   sudo: yes
   with_items:
-    - mariadb-client
+    - mysql-client-5.6
     - imagemagick


### PR DESCRIPTION
Due to migration to RDS.
