### PR TITLE
Removes app shared var.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # vars file for dosomething
-app_shared: "{{ app_root }}/shared"
+


### PR DESCRIPTION
So when `current` symlink is used, shared folder doesn't end up in it.
It will be required to setup `app_shared` manually.
