### PR TITLE
Nginx: always pass fastcgi_param HTTPS.

### DIFF
--- a/templates/nginx/app.j2
+++ b/templates/nginx/app.j2
@@ -53,10 +53,7 @@ server {
     fastcgi_index  index.php;
     include fastcgi_params;
 
-    {% if app_ssl_enabled %}
     fastcgi_param  HTTPS $https;
-    {% endif %}
-
     fastcgi_param  SCRIPT_FILENAME  {{ app_root }}/html$fastcgi_script_name;
     fastcgi_param  QUERY_STRING     $query_string;
     fastcgi_param  REQUEST_METHOD   $request_method;


### PR DESCRIPTION
Ref http://nginx.org/en/docs/http/ngx_http_core_module.html#var_https
