### PR TITLE
Fixes #35: Updates staging URL to stagingdata.dosomething.org

### DIFF
--- a/templates/drush/ds.aliases.drushrc.php.j2
+++ b/templates/drush/ds.aliases.drushrc.php.j2
@@ -30,9 +30,9 @@ $aliases["default"] = array (
 );
 
 $aliases['staging'] = array(
- 'uri' => 'staging.beta.dosomething.org',
+ 'uri' => 'stagingdata.dosomething.org',
  'root' => '/var/www/staging.beta.dosomething.org/current/html',
- 'remote-host' => 'staging.beta.dosomething.org',
+ 'remote-host' => 'stagingdata.dosomething.org',
  'remote-user' => 'dosomething',
  'path-aliases' => array(
    '%files' => '/var/www/staging.beta.dosomething.org/shared/files',


### PR DESCRIPTION
#### What's this PR do?

Updates the staging URL to bypass the general URL (staging.beta.dosomething.org), which is now CNAMEd to Fastly.
#### Where should the reviewer start?

Simple change -- just the two actual URL references in the drush aliases file.
#### How should this be manually tested?
1. Update your local aliases file.
2. Try a `drush @ds.staging status` or, during a rebuild, a `ds pull stage`
3. Confirm that (a) the script is calling `stagingdata.dosomething.org` and (b) the script is working
4. Confirm from inside and outside the DS.org office network
#### Any background context you want to provide?

N/A
#### What are the relevant tickets?
#35
#### Screenshots (if appropriate)

N/A
#### Questions:
- Is there a blog post? _N/A_
- Does the knowledge base need an update? _Possibly_ -- If there are any explicit references to `staging.beta.dosomething.org`
- Does this add new dependencies which need to be added to Ansible? _No_, but we will need to update the Vagrant box @sergii-tkachenko 
